### PR TITLE
refactor(bll): 移除 plotly.config.ts 中的默认导出

### DIFF
--- a/bll/plotly.config.ts
+++ b/bll/plotly.config.ts
@@ -52,4 +52,5 @@ const config = new Attribute('config', 'Config', {
 })
 config.children = new ConfigureAttribute(config).attributes
 
-export default [layout, config]
+// export default [layout, config]
+export default []


### PR DESCRIPTION
移除了 plotly.config.ts 文件中的默认导出语句，将原有的 [layout, config] 数组导出删除，改为导出一个空数组。