### PR TITLE
refactor(PlotlyConfigView): 注释掉 PlotlyDisplay 组件

### DIFF
--- a/src/views/PlotlyConfigView/index.vue
+++ b/src/views/PlotlyConfigView/index.vue
@@ -98,7 +98,7 @@ onMounted(() => {
             :class="rightSideClass"
             :style="{ height: direction === 'horizontal' ? 'calc(100vh - 60px)' : '40vh' }"
           >
-            <PlotlyDisplay ref="plotlyDisplay" :direction="direction" />
+            <!-- <PlotlyDisplay ref="plotlyDisplay" :direction="direction" /> -->
           </div>
         </div>
       </el-scrollbar>


### PR DESCRIPTION
在 PlotlyConfigView 组件中，将 PlotlyDisplay 组件用注释标记包围，暂时移除其渲染。 这个改动可能是为了调试或重新设计图表显示逻辑。