### PR TITLE
refactor(bll): 更新 Plotly 配置导出

### DIFF
--- a/bll/plotly.config.ts
+++ b/bll/plotly.config.ts
@@ -52,5 +52,4 @@ const config = new Attribute('config', 'Config', {
 })
 config.children = new ConfigureAttribute(config).attributes
 
-// export default [layout, config]
-export default []
+export default [layout, config]

--- a/src/views/PlotlyConfigView/index.vue
+++ b/src/views/PlotlyConfigView/index.vue
@@ -81,7 +81,7 @@ onMounted(() => {
           :style="{ minHeight: 'calc(100vh - 60px)' }"
         >
           <div class="flex-auto p-4 bg-white min-w-0">
-            <!-- <el-tree
+            <el-tree
               :data="branch"
               node-key="id"
               default-expand-all
@@ -91,7 +91,7 @@ onMounted(() => {
               <template #default="{ node, data }">
                 <AttributeDisplay class="cursor-default" :data="data" :node="node" />
               </template>
-            </el-tree> -->
+            </el-tree>
           </div>
           <div
             class="flex-shrink-0 bg-white"


### PR DESCRIPTION
- 重新启用 Plotly 配置的导出
- 注释掉的代码行被恢复，使得 [layout, config] 被正确导出
- 移除了多余的空行

fix(src): 显示 Plotly 配置树

- 重新显示之前被注释掉的 el-tree 组件
- 这个修改使得 Plotly 配置可以再次在界面上展示