### PR TITLE
refactor(PlotDisplay): 注释掉挂载时渲染图表的代码

### DIFF
--- a/src/views/PlotlyConfigView/PlotDisplay.vue
+++ b/src/views/PlotlyConfigView/PlotDisplay.vue
@@ -51,7 +51,7 @@ function renderPlot() {
 }
 
 onMounted(() => {
-  renderPlot()
+  // renderPlot()
 })
 </script>
 


### PR DESCRIPTION
- 在 PlotDisplay.vue 文件中，注释掉了 onMounted 钩子内的 renderPlot() 函数调用
- 此修改可能是为了优化图表渲染时机或解决某些图表显示问题