### PR TITLE
refactor(PlotDisplay): 重新引入 usePlotly 钩子

### DIFF
--- a/src/views/PlotlyConfigView/PlotDisplay.vue
+++ b/src/views/PlotlyConfigView/PlotDisplay.vue
@@ -2,7 +2,7 @@
 import { nextTick, onMounted, watch } from 'vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import { Monitor, CloseBold } from '@element-plus/icons-vue'
-// import { usePlotly } from '@/utils/usePlotly'
+import { usePlotly } from '@/utils/usePlotly'
 import { useStorage } from '@vueuse/core'
 import { usePloyConfigStore } from '@/stores/ploy.config'
 import { storeToRefs } from 'pinia'


### PR DESCRIPTION
- 在 PlotDisplay 组件中重新引入了之前被注释掉的 usePlotly 钩子
- 这个改动可能是为了恢复使用 Plotly 图表功能