### PR TITLE
refactor(PlotDisplay): 注释掉绘图函数调用

### DIFF
--- a/src/views/PlotlyConfigView/PlotDisplay.vue
+++ b/src/views/PlotlyConfigView/PlotDisplay.vue
@@ -45,7 +45,7 @@ function renderPlot() {
     const { data = {}, layout, config } = JSON.parse(JSON.stringify(plotlyConfig.value))
 
     const traces = Array.isArray(data) ? data : [data]
-    usePlotly('PlotContainer', traces, false, layout, config)
+    // usePlotly('PlotContainer', traces, false, layout, config)
   })
 }
 


### PR DESCRIPTION
- 在 PlotDisplay.vue 文件中，注释掉了 usePlotly 函数的调用
- 这可能是为了暂时禁用绘图功能或进行调试