### PR TITLE
refactor(PlotDisplay): 恢复渲染函数和生命周期钩子

### DIFF
--- a/src/views/PlotlyConfigView/PlotDisplay.vue
+++ b/src/views/PlotlyConfigView/PlotDisplay.vue
@@ -34,7 +34,7 @@ defineProps({
 watch(
   [() => plotlyConfig.value, openDisplay],
   () => {
-    // renderPlot()
+    renderPlot()
   },
   { deep: true }
 )
@@ -49,9 +49,9 @@ function renderPlot() {
   })
 }
 
-// onMounted(() => {
-//   renderPlot()
-// })
+onMounted(() => {
+  renderPlot()
+})
 </script>
 
 <template>


### PR DESCRIPTION
- 移除了 watch 函数中的注释，恢复了 renderPlot 函数的调用
- 移除了 onMounted 函数的注释，恢复了在组件挂载时调用 renderPlot