### PR TITLE
refactor(utils): 移除 usePlotly 中未使用的 plotly 属性

### DIFF
--- a/src/utils/usePlotly.ts
+++ b/src/utils/usePlotly.ts
@@ -4,7 +4,6 @@ import { ref } from 'vue'
 import type { Ref } from 'vue'
 
 export interface UsePlotly {
-  plotly: Promise<Plotly.PlotlyHTMLElement>
   plotlyTemplate: Ref<Plotly.Template | null>
 
   /**
@@ -203,7 +202,6 @@ export function usePlotly(
   }
 
   return {
-    plotly,
     plotlyTemplate,
     react(data, layout, config) {
       const promise = Plotly.react(gd, data, layout, config)


### PR DESCRIPTION
- 删除了 UsePlotly 接口中的 plotly 属性
- 从 usePlotly 函数的返回值中移除了 plotly
- 这个属性在代码中没有被使用，移除它可以简化代码结构