### PR TITLE
build(vite): 注释掉 terserOptions 中的 compress 和 format 配置

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,15 +42,15 @@ export default defineConfig(async () => {
         }
       },
       terserOptions: {
-        compress: {
-          reduce_vars: true, // 优化变量使用（减少重复声明）
-          booleans_as_integers: true, // 将布尔值转为 0/1 进一步压缩
-          drop_console: true, // 删除所有console
-          drop_debugger: true // 删除所有debugger
-        },
-        format: {
-          comments: false // 删除所有注释
-        }
+        // compress: {
+        //   reduce_vars: true, // 优化变量使用（减少重复声明）
+        //   booleans_as_integers: true, // 将布尔值转为 0/1 进一步压缩
+        //   drop_console: true, // 删除所有console
+        //   drop_debugger: true // 删除所有debugger
+        // },
+        // format: {
+        //   comments: false // 删除所有注释
+        // }
       }
     },
     // devServer 配置


### PR DESCRIPTION
- 注释掉了 terserOptions 中的 compress 和 format 配置选项
- 这些配置选项用于代码压缩和格式化，注释掉后可能会影响代码构建结果