### PR TITLE
refactor(components): 移除未使用的组件声明并修复类型定义

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -9,13 +9,11 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     AttributeControl: typeof import('./src/components/AttributeControl.vue')['default']
-    'Base.ids': typeof import('./src/components/doc/traces/base.ids.vue')['default']
     BaseIds: typeof import('./src/components/doc/traces/BaseIds.vue')['default']
     BaseX0: typeof import('./src/components/doc/traces/BaseX0.vue')['default']
     BasicAside: typeof import('./src/components/BasicAside.vue')['default']
     CodeAndPlot: typeof import('./src/components/CodeAndPlot.vue')['default']
     CodeEditor: typeof import('./src/components/CodeEditor.vue')['default']
-    copy: typeof import('./src/components/doc/traces/ViolinAlignmentGroup copy.vue')['default']
     DataRevision: typeof import('./src/components/doc/layout/DataRevision.vue')['default']
     EditRevision: typeof import('./src/components/doc/layout/EditRevision.vue')['default']
     ElAside: typeof import('element-plus/es')['ElAside']
@@ -55,8 +53,6 @@ declare module 'vue' {
     Template: typeof import('./src/components/doc/layout/Template.vue')['default']
     TraceData: typeof import('./src/components/doc/TraceData.vue')['default']
     UiRevision: typeof import('./src/components/doc/layout/UiRevision.vue')['default']
-    ViolinAlignentGroup: typeof import('./src/components/doc/traces/ViolinAlignentGroup.vue')['default']
     ViolinAlignmentGroup: typeof import('./src/components/doc/traces/ViolinAlignmentGroup.vue')['default']
-    ViolinScaleGroup: typeof import('./src/components/doc/traces/ViolinScaleGroup.vue')['default']
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tsconfig/node18": "^2.0.1",
     "@types/codemirror": "^5.60.16",
     "@types/jsdom": "^21.1.1",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^18.16.17",
     "@types/plotly.js": "^3.0.2",
     "@vitejs/plugin-vue": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,6 +596,11 @@
   resolved "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
+"@types/linkify-it@^5":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-5.0.0.tgz#21413001973106cda1c3a9b91eedd4ccd5469d76"
+  integrity sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
+
 "@types/lodash-es@^4.17.6":
   version "4.17.12"
   resolved "https://registry.npmmirror.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
@@ -607,6 +612,19 @@
   version "4.17.20"
   resolved "https://registry.npmmirror.com/@types/lodash/-/lodash-4.17.20.tgz#1ca77361d7363432d29f5e55950d9ec1e1c6ea93"
   integrity sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==
+
+"@types/markdown-it@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-14.1.2.tgz#57f2532a0800067d9b934f3521429a2e8bfb4c61"
+  integrity sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==
+  dependencies:
+    "@types/linkify-it" "^5"
+    "@types/mdurl" "^2"
+
+"@types/mdurl@^2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-2.0.0.tgz#d43878b5b20222682163ae6f897b20447233bdfd"
+  integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
 "@types/node@*":
   version "20.3.3"


### PR DESCRIPTION
移除了 components.d.ts 中以下未使用的组件声明：
- Base.ids (已重命名为 BaseIds)
- ViolinAlignentGroup (拼写错误已修正为 ViolinAlignmentGroup)
- ViolinScaleGroup
- copy (重复组件)

同时添加了 @types/markdown-it 依赖以支持 Markdown 相关功能，
并更新了 yarn.lock 文件以同步依赖关系变更。